### PR TITLE
Removes unsupported warning on MacOS

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-const userAgent = "Chrome";
+const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36";
 const signInURL =
   "https://accounts.google.com/signin/v2/identifier?service=wise&passive=true&continue=http%3A%2F%2Fdrive.google.com%2F%3Futm_source%3Den&utm_medium=button&utm_campaign=web&utm_content=gotodrive&usp=gtd&ltmpl=drive&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36";
+const userAgent = "Mozilla/5.0 (Macintosh; ; ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36";
 const signInURL =
   "https://accounts.google.com/signin/v2/identifier?service=wise&passive=true&continue=http%3A%2F%2Fdrive.google.com%2F%3Futm_source%3Den&utm_medium=button&utm_campaign=web&utm_content=gotodrive&usp=gtd&ltmpl=drive&flowName=GlifWebSignIn&flowEntry=ServiceLogin";
 


### PR DESCRIPTION
### Fixing issue #25 on MacOS

Opening up a PR that fixes the issue on MacOS, don't have other OSes like Windows or Linux so will need some tests to see if it fixes for those OSes.

This is a workaround solution based on [this](https://stackoverflow.com/questions/51017928/electron-webview-chrome-is-obsolete).

Probably going to have to set a enum for other OSes like Windows in config.js as it seems the string I put in for useragent is MacOS-specific, so can add that to this PR if needed.

**Before:**
![Screen Shot 2020-05-16 at 12 54 34 AM](https://user-images.githubusercontent.com/9067177/82131593-c2643800-97a4-11ea-9922-ef31c41c095c.png)

**After:**
![Screen Shot 2020-05-16 at 6 41 36 PM](https://user-images.githubusercontent.com/9067177/82131609-ea539b80-97a4-11ea-9e25-8bd226329509.png)

