### PR TITLE
Have window focus persist on switch.

### DIFF
--- a/src/javascripts/childwindow.js
+++ b/src/javascripts/childwindow.js
@@ -116,6 +116,13 @@ var createChildWindow = function (event, url, frameName, disposition, options) {
     childview = null;
   });
 
+  // When window is refocused, focus on webview to persist focus
+  childwin.on("focus", () => {
+    if (childview?.webContents) {
+      childview.webContents.focus();
+    }
+  });
+
   electronLocalshortcut.register(childview, ["CmdOrCtrl+R", "F5"], () => {
     childview.webContents.loadURL(windowSettings.url);
   });

--- a/src/javascripts/mainwindow.js
+++ b/src/javascripts/mainwindow.js
@@ -141,6 +141,13 @@ var createMainWindow = () => {
     view = null;
   });
 
+  // When window is refocused, focus on webview to persist focus
+  win.on("focus", () => {
+    if (view?.webContents) {
+      view.webContents.focus();
+    }
+  });
+
   electronLocalshortcut.register(view, ["CmdOrCtrl+R", "F5"], () => {
     // No reload API for browserview yet.
     view.webContents.loadURL(windowSettings.url, { userAgent });


### PR DESCRIPTION
Each window is made up of two components, the window and the view. By default Electron will refocus on the window instead of the view with the actual webcontents inside. This breaks persisting focus while switching windows (#37).

Added a `on.focus` listener and call `view.webContents.focus()`.

Resolves #37.