### PR TITLE
Issue 22 window sizing platforms

### DIFF
--- a/src/javascripts/childwindow.js
+++ b/src/javascripts/childwindow.js
@@ -68,9 +68,9 @@ var createChildWindow = function (event, url, frameName, disposition, options) {
   childview.setBounds({
     x: 0,
     y: TITLE_BAR_HEIGHT,
-    width: options.size ? options.size[0] : childWindowState.width,
+    width: options.size ? options.size[0] : childwin.getSize()[0],
     height:
-      (options.size ? options.size[1] : childWindowState.height) -
+      (options.size ? options.size[1] : childwin.getSize()[1]) -
       TITLE_BAR_HEIGHT,
   });
   childview.setAutoResize({

--- a/src/javascripts/childwindow.js
+++ b/src/javascripts/childwindow.js
@@ -68,9 +68,9 @@ var createChildWindow = function (event, url, frameName, disposition, options) {
   childview.setBounds({
     x: 0,
     y: TITLE_BAR_HEIGHT,
-    width: options.size ? options.size[0] : childwin.getSize()[0],
+    width: options.size ? options.size[0] : childwin.getContentBounds().width,
     height:
-      (options.size ? options.size[1] : childwin.getSize()[1]) -
+      (options.size ? options.size[1] : childwin.getContentBounds().height) -
       TITLE_BAR_HEIGHT,
   });
   childview.setAutoResize({

--- a/src/javascripts/mainwindow.js
+++ b/src/javascripts/mainwindow.js
@@ -75,8 +75,8 @@ var createMainWindow = () => {
   view.setBounds({
     x: 0,
     y: TITLE_BAR_HEIGHT,
-    width: win.getSize()[0],
-    height: win.getSize()[1] - TITLE_BAR_HEIGHT,
+    width: win.getContentBounds().width,
+    height: win.getContentBounds().height - TITLE_BAR_HEIGHT,
   });
   view.setAutoResize({
     width: true,

--- a/src/javascripts/mainwindow.js
+++ b/src/javascripts/mainwindow.js
@@ -75,8 +75,8 @@ var createMainWindow = () => {
   view.setBounds({
     x: 0,
     y: TITLE_BAR_HEIGHT,
-    width: mainWindowState.width,
-    height: mainWindowState.height - TITLE_BAR_HEIGHT,
+    width: win.getSize()[0],
+    height: win.getSize()[1] - TITLE_BAR_HEIGHT,
   });
   view.setAutoResize({
     width: true,


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Hold | Bug | No |

> ⚠️ NOTE: use notes like this to emphasize something about the PR. This could include other PRs this PR is built on top of; new or removed environment variables; reasons for why the PR is on hold; or anything else you would like to draw attention to.

## Problem

Resolves #22.


## Solution

Change the way bounds for the view windows are being found. I was using previous window state to calculate the current view size, but this PR uses the webcontent bounds of the main window.


## Before & After Screenshots

**BEFORE**:
![Annotation 2020-05-19 013636](https://user-images.githubusercontent.com/13460330/82288775-3f440d00-9971-11ea-87b9-6d60df23ffb0.png)

**AFTER**:
![Annotation 2020-05-19 013604](https://user-images.githubusercontent.com/13460330/82288781-43702a80-9971-11ea-901f-aea70ca136a8.png)

