### PR TITLE
Add aur instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Simply run `brew cask upgrade` to get the latest version of the app.
 
 ### For Arch Linux and related distirubtions ###
 
-Install the AUR package [`g-desktop-suite-git`](https://aur.archlinux.org/packages/g-desktop-suite-git/).
+Install the AUR package [`g-desktop-suite-git`](https://aur.archlinux.org/packages/g-desktop-suite-git/). Below is an example with yay, but any AUR manager will work.
 
 ```sh
-pacman -S g-desktop-suite-git
+yay -S g-desktop-suite-git
 ```
 
 ### 🎶 Versions

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ brew cask install g-desktop-suite
 
 Simply run `brew cask upgrade` to get the latest version of the app.
 
+### For Arch Linux and related distirubtions ###
+
+Install the AUR package [`g-desktop-suite-git`](https://aur.archlinux.org/packages/g-desktop-suite-git/).
+
+```sh
+pacman -S g-desktop-suite-git
+```
+
 ### 🎶 Versions
 
 - v.conscious-club / 0.2.0-0.2.1


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |


## Problem

Users can install on the Arch Linux package manager but cannot find out how via the instructions.

## Solution

Direct them to the package.
