### PR TITLE
Make store accessible to renderer processes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,15 +7,12 @@ const {
   app,
 } = require("electron");
 
-const createStore = require("./src/helpers/store");
+const store = require("./src/helpers/store");
 const config = require("./src/helpers/config");
 const {
   CONSTANTS: { OS_PLATFORMS, THEME_OPTIONS },
 } = require("./src/helpers/util");
 const { createMainWindow } = require("./src/js/mainwindow");
-
-// Create store only once in app root.
-let store = createStore();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -1,13 +1,11 @@
 const Store = require("electron-store");
 
-module.exports = () => {
-  const schema = {
-    theme: {
-      type: "string",
-      enum: ["auto", "light", "dark"],
-      default: "auto",
-    },
-  };
-
-  return new Store({ schema });
+const schema = {
+  theme: {
+    type: "string",
+    enum: ["auto", "light", "dark"],
+    default: "auto",
+  },
 };
+
+module.exports = new Store({ schema });

--- a/src/js/childwindow.js
+++ b/src/js/childwindow.js
@@ -1,9 +1,4 @@
-const {
-  screen,
-  BrowserView,
-  BrowserWindow,
-  Menu
-} = require("electron");
+const { screen, BrowserView, BrowserWindow, Menu } = require("electron");
 const windowState = require("electron-window-state");
 const electronLocalshortcut = require("electron-localshortcut");
 const path = require("path");
@@ -67,10 +62,8 @@ var createChildWindow = function (event, url, frameName, disposition, options) {
   childview.setBounds({
     x: 0,
     y: TITLE_BAR_HEIGHT,
-    width: options.size ? options.size[0] : childwin.getContentBounds().width,
-    height:
-      (options.size ? options.size[1] : childwin.getContentBounds().height) -
-      TITLE_BAR_HEIGHT,
+    width: childwin.getContentBounds().width,
+    height: childwin.getContentBounds().height - TITLE_BAR_HEIGHT,
   });
   childview.setAutoResize({
     width: true,


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No |


## Problem

Resolves #60.

Make store accessible to renderer processes without cyclic require hell.


## Solution

Export initialized store in `store.js`
