### PR TITLE
Also set document title tag

### DIFF
--- a/src/js/preload.js
+++ b/src/js/preload.js
@@ -16,6 +16,7 @@ window.addEventListener("DOMContentLoaded", () => {
   // Receive title from child preload view
   ipcRenderer.on("title-reply", function (_, title) {
     titleBar.innerHTML = title;
+    document.title = title;
   });
 
   ipcRenderer.send("title-request");


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

All windows had the same native window title of "Google Drive". This is visible in a couple places, including the dock icon.

## Solution

It looked like this string was coming from the document's `title` tag, so I changed `preload.js` to change it when it sets the titlebar content.

## Before & After Screenshots

**BEFORE**:
<img width="213" alt="Before" src="https://user-images.githubusercontent.com/732173/82963069-c3505300-9f76-11ea-9602-0fdb64b5f669.png">

**AFTER**:
<img width="213" alt="Screen_Shot_2020-05-26_at_5 22 06_PM" src="https://user-images.githubusercontent.com/732173/82963106-d400c900-9f76-11ea-8e98-a3ce0ad6d2be.png">
Note: I assume the icon is wrong in the screenshot because I ran it with `yarn start`