### PR TITLE
update brew cask install command in Github Actions build scripts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install brew, cask, and wine
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-          brew cask install xquartz
-          brew cask install wine-stable
+          brew install --cask xquartz
+          brew install --cask wine-stable
           brew install rpm
     
       - name: Build with electron-builder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install brew, cask, and wine
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-          brew cask install xquartz
-          brew cask install wine-stable
+          brew install --cask xquartz
+          brew install --cask wine-stable
           brew install rpm
     
       - name: Deploy with electron-builder


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready| Tooling | No |


## Problem

Current Github Actions builds are failing as the master branch of Homebrew has changed the cask install command format.

## Solution

This PR will update the brew install commands in the build scripts. There's already a related PR (#114) open to fix README.