### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This method is highly recommended for users who want the latest release without 
 The following script will install `G Desktop Suite.app` into your `Applications/` folder.
 
 ```sh
-brew cask install g-desktop-suite
+brew install --cask g-desktop-suite
 ```
 
 Run `brew cask upgrade` to get the latest version of the app.


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524